### PR TITLE
ABYSSP-431 Deploy into Github

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -493,6 +493,11 @@
                 <version>${version.jackson-core}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${version.jackson-core}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.verapi.abyss</groupId>
                 <artifactId>abyss-json-schema-validator</artifactId>
                 <version>${version.json-schema-validator}</version>
@@ -598,9 +603,14 @@
     <build>
         <extensions>
             <extension>
+                <groupId>org.apache.maven.doxia</groupId>
+                <artifactId>doxia-module-markdown</artifactId>
+                <version>1.9</version>
+            </extension>
+            <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-scm</artifactId>
-                <version>3.3.2</version>
+                <version>3.3.3</version>
             </extension>
             <extension>
                 <groupId>org.apache.maven.scm</groupId>
@@ -1140,7 +1150,7 @@
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-module-markdown</artifactId>
-                        <version>1.8</version>
+                        <version>1.9</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>
@@ -1150,7 +1160,7 @@
                     <dependency>
                         <groupId>org.apache.maven.wagon</groupId>
                         <artifactId>wagon-scm</artifactId>
-                        <version>3.3.2</version>
+                        <version>3.3.3</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>


### PR DESCRIPTION
	Dependencies used by Abyss Identity Manager declared
	wagon-scm and doxia-module-markdown depenencies upgraded